### PR TITLE
Image Feed: UX Overhauling

### DIFF
--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -5,44 +5,68 @@ import { lightbox } from "./common/lightbox.js";
 
 $el("style", {
 	textContent: `
-	.pysssss-image-feed {
+	.pysssss-image-feed-root {
+		--image-size: 128px;
+		--image-gap-size: 4px;
+
+		--image-feed-radius: 5px;
+		--image-feed-theme-handle: #333;
+		
+
+		align-items: stretch;
+		display: flex;
+		font-size: 12px;
 		position: absolute;
+		text-align: center;
+		vertical-align: top;
+		z-index: 99;
+	}
+	.pysssss-image-feed-root--left, .pysssss-image-feed-root--right {
+		top: 0;
+		height: 100vh;
+		width: calc(var(--image-size) + 76px);
+	}
+	.pysssss-image-feed-root--left {
+		left: 0;
+	}
+	.pysssss-image-feed-root--right {
+		right: 0;
+		flex-direction: row-reverse;
+	}
+	.pysssss-image-feed-root--top, .pysssss-image-feed-root--bottom {
+		left: 0;
+		width: 100vw;
+		height: calc(var(--image-size) + 76px);
+	}
+	.pysssss-image-feed-root--top {
+		top: 0;
+		flex-direction: column;
+	}
+	.pysssss-image-feed-root--bottom {
+		bottom: 0;
+		flex-direction: column-reverse;
+	}
+	.pysssss-image-feed {
+		flex: 1;
 		background: var(--comfy-menu-bg);
 		color: var(--fg-color);
-		z-index: 99;
 		font-family: sans-serif;
 		font-size: 12px;
 		display: flex;
 		flex-direction: column;
-	}
-	.pysssss-image-feed--top, .pysssss-image-feed--bottom {
-		width: 100vw;
-		min-height: 30px;
-		max-height: calc(var(--max-size, 20) * 1vh);
-	}
-	.pysssss-image-feed--top {
-		top: 0;
-	}
-	.pysssss-image-feed--bottom {
-		bottom: 0;
-		flex-direction: column-reverse;
-		padding-top: 5px;
+		width: 100%;
+		height: 100%;
 	}
 	.pysssss-image-feed--left, .pysssss-image-feed--right {
 		top: 0;
 		height: 100vh;
-		min-width: 200px;
-		max-width: calc(var(--max-size, 10) * 1vw);
-	}
-	.pysssss-image-feed--left {
-		left: 0;
-	}
-	.pysssss-image-feed--right {
-		right: 0;
+		width: 100%;
 	}
 
-	.pysssss-image-feed--left .pysssss-image-feed-menu, .pysssss-image-feed--right .pysssss-image-feed-menu {
-		flex-direction: column;
+	.pysssss-image-feed--top, .pysssss-image-feed--bottom {
+		left: 0;
+		width: 100vw;
+		height: 100%;
 	}
 
 	.pysssss-image-feed-menu {
@@ -62,7 +86,7 @@ $el("style", {
 	}
 	.pysssss-image-feed-btn {
 		background-color:var(--comfy-input-bg);
-		border-radius:5px;
+		border-radius: var(--image-feed-radius);
 		border:2px solid var(--border-color);
 		color: var(--fg-color);
 		cursor:pointer;
@@ -87,9 +111,8 @@ $el("style", {
 		position:relative;
 		top:1px;
 	}
-	
 	.pysssss-image-feed-menu section {
-		border-radius: 5px;
+		border-radius: var(--image-feed-radius);
 		background: rgba(0,0,0,0.6);
 		padding: 0 5px;
 		display: flex;
@@ -103,7 +126,7 @@ $el("style", {
 	.pysssss-image-feed-menu section input {
 		flex: 1 1 100%;
 		background: rgba(0,0,0,0.6);
-		border-radius: 5px;
+		border-radius: var(--image-feed-radius);
 		overflow: hidden;
 		z-index: 100;
 	}
@@ -122,6 +145,7 @@ $el("style", {
 	}
 
 	.sizing-menu:hover .size-controls-flyout {
+		position: absolute;
 		transform: scale(1, 1);
 		transition: 200ms linear;
 		transition-delay: 0;
@@ -150,57 +174,86 @@ $el("style", {
 		top: 0;
 		right: 0;
 	}
-	
+
 	.pysssss-image-feed-menu > * {
 		min-height: 24px;
 	}
 	.pysssss-image-feed-list {
-		flex: 1 1 auto;
+		align-content: flex-start;
 		overflow-y: auto;
 		display: grid;
+		gap: var(--image-gap-size);
+		grid-template-columns: repeat( auto-fit, minmax(var(--image-size, 128), 1fr) );
 		align-items: center;
-		justify-content: center;
-		gap: 4px;
-		grid-auto-rows: min-content;
-		grid-template-columns: repeat(var(--img-sz, 3), 1fr);
+      	justify-items: center;
 		transition: 100ms linear;
 		scrollbar-gutter: stable both-edges;
 		padding: 5px;
 		background: var(--comfy-input-bg);
-		border-radius: 5px;
+		border-radius: var(--image-feed-radius);
 		margin: 5px;
 		margin-top: 0px;
+		height: 100%;
 	}
-	.pysssss-image-feed-list:empty {
-		display: none;
+	.pysssss-image-feed-list div, .pysssss-image-feed-list a {
+		display: flex;
+		flex-wrap: wrap;
+		width: var(--image-size);
+		height: var(--image-size);
+		align-content: center;
+		justify-content: center;
 	}
 	.pysssss-image-feed-list div {
-		height: 100%;
-		text-align: center;
+		background: rgba(0,0,0,0.15);
+		box-sizing: border-box;
+	}
+	.pysssss-image-feed-list div:hover{
+		filter: brightness(1.2);
+	}
+	.pysssss-image-feed-list img {
+		max-width: 100%;
+      	max-height: 100%;
 	}
 	.pysssss-image-feed-list::-webkit-scrollbar {
 		background: var(--comfy-input-bg);
-		border-radius: 5px;
+		border-radius: var(--image-feed-radius);
 	}
 	.pysssss-image-feed-list::-webkit-scrollbar-thumb {
 		background:var(--comfy-menu-bg);
 		border: 5px solid transparent;
-		border-radius: 8px;
+		border-radius: var(--image-feed-radius);
 		background-clip: content-box;
 	}
 	.pysssss-image-feed-list::-webkit-scrollbar-thumb:hover {
 		background: var(--border-color);
 		background-clip: content-box;
 	}
-	.pysssss-image-feed-list img {
-		object-fit: var(--img-fit, contain);
-		max-width: 100%;
-		max-height: calc(var(--max-size) * 1vh);
-		border-radius: 4px;
+	.pysssss-image-feed-handle {
+		flex: 0;
+		background-color: #191919;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		/* Disables dragging so it doesn't mess up the grab. */
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
 	}
-	.pysssss-image-feed-list img:hover {
-		filter: brightness(1.2);
-	}`,
+	.pysssss-image-feed-handle--left, .pysssss-image-feed-handle--right {
+		cursor: col-resize;
+		min-width: 8px;
+		height: 100vh;
+	}
+	.pysssss-image-feed-handle--top, .pysssss-image-feed-handle--bottom {
+		cursor: row-resize;
+		min-height: 8px;
+		width: 100vw;
+	}
+	.pysssss-image-feed-handle:hover, .pysssss-image-feed-handle:active {
+		background-color: var(--border-color);
+	}
+	`,
 	parent: document.body,
 });
 
@@ -229,10 +282,17 @@ app.registerExtension({
 			localStorage.setItem("pysssss.ImageFeed." + n, v);
 		};
 
-		const imageFeed = $el("div.pysssss-image-feed", {
+		const imageFeedRoot = $el("div.pysssss-image-feed-root", {
 			parent: document.body,
 		});
+
+		const imageFeed = $el("div.pysssss-image-feed");
+
 		const imageList = $el("div.pysssss-image-feed-list");
+
+		const resizeHandle = $el("div.pysssss-image-feed-handle");
+
+		imageFeedRoot.append(imageFeed, resizeHandle);
 
 		const feedLocation = app.ui.settings.addSetting({
 			id: "pysssss.ImageFeed.Location",
@@ -254,7 +314,7 @@ app.registerExtension({
 								},
 								oninput: (e) => {
 									feedLocation.value = e.target.value;
-									imageFeed.className = `pysssss-image-feed pysssss-image-feed--${feedLocation.value}`;
+									onFeedLocationChange(feedLocation.value);
 								},
 							},
 							["left", "top", "right", "bottom"].map((m) =>
@@ -269,9 +329,22 @@ app.registerExtension({
 				]);
 			},
 			onChange(value) {
-				imageFeed.className = `pysssss-image-feed pysssss-image-feed--${value}`;
+				onFeedLocationChange(value);
 			},
 		});
+
+		function onFeedLocationChange(value) {
+			imageFeed.className = `pysssss-image-feed pysssss-image-feed--${value}`;
+			imageFeedRoot.className = `pysssss-image-feed-root pysssss-image-feed-root--${value}`;
+			resizeHandle.className = `pysssss-image-feed-handle pysssss-image-feed-handle--${value}`;
+			if (["left", "right"].includes(value)) {
+				imageFeedRoot.style.width = "max(calc(var(--image-size) + 32px), 200px)";
+				imageFeedRoot.style.height = "unset";
+			} else {
+				imageFeedRoot.style.height = "max(calc(var(--image-size) + 32px), 200px)";
+				imageFeedRoot.style.width = "unset";
+			}
+		}
 
 		const feedDirection = app.ui.settings.addSetting({
 			id: "pysssss.ImageFeed.Direction",
@@ -317,7 +390,7 @@ app.registerExtension({
 		const hideButton = $el("button.pysssss-image-feed-btn.hide-btn", {
 			textContent: "❌",
 			onclick: () => {
-				imageFeed.style.display = "none";
+				imageFeedRoot.style.display = "none";
 				showButton.style.display = "unset";
 				saveVal("Visible", 0);
 				visible = false;
@@ -327,44 +400,26 @@ app.registerExtension({
 		imageFeed.append(
 			$el("div.pysssss-image-feed-menu", [
 				$el("section.sizing-menu", {}, [
-					$el("label.size-control-handle", { textContent: "↹ Resize Feed" }),
+					$el("label.size-control-handle", { textContent: "⚙️" }),
 					$el("div.size-controls-flyout", {}, [
 						$el("section.size-control.feed-size-control", {}, [
 							$el("span", {
-								textContent: "Feed Size...",
+								textContent: "Image Size",
 							}),
 							$el("input", {
 								type: "range",
-								min: 10,
-								max: 80,
+								min: 32,
+								max: 512,
+								step: 12,
 								oninput: (e) => {
-									e.target.parentElement.title = `Controls the maximum size of the image feed panel (${e.target.value}vh)`;
-									imageFeed.style.setProperty("--max-size", e.target.value);
-									saveVal("FeedSize", e.target.value);
-								},
-								$: (el) => {
-									requestAnimationFrame(() => {
-										el.value = getVal("FeedSize", 25);
-										el.oninput({ target: el });
-									});
-								},
-							}),
-						]),
-						$el("section.size-control.image-size-control", {}, [
-							$el("span", { textContent: "Column count..." }),
-							$el("input", {
-								type: "range",
-								min: 1,
-								max: 10,
-								step: 1,
-								oninput: (e) => {
-									e.target.parentElement.title = `Controls the number of columns in the feed (${e.target.value} columns)`;
-									imageFeed.style.setProperty("--img-sz", e.target.value);
+									e.target.parentElement.title = `Controls the maximum size of the images in the feed panel (${e.target.value}px/512px)`;
+									imageFeedRoot.style.setProperty("--image-size", `${e.target.value}px` );
 									saveVal("ImageSize", e.target.value);
+									e.target.textContent = `${e.target.value}px/512px`;
 								},
 								$: (el) => {
 									requestAnimationFrame(() => {
-										el.value = getVal("ImageSize", 4);
+										el.value = getVal("ImageSize", 128);
 										el.oninput({ target: el });
 									});
 								},
@@ -377,7 +432,7 @@ app.registerExtension({
 			imageList
 		);
 		showButton.onclick = () => {
-			imageFeed.style.display = "block";
+			imageFeedRoot.style.display = "flex";
 			showButton.style.display = "none";
 			saveVal("Visible", 1);
 			visible = true;
@@ -402,6 +457,7 @@ app.registerExtension({
 								"a",
 								{
 									target: "_blank",
+									draggable: false,
 									href,
 									onclick: (e) => {
 										const imgs = [...imageList.querySelectorAll("img")].map((img) => img.getAttribute("src"));
@@ -416,5 +472,80 @@ app.registerExtension({
 				}
 			}
 		});
+
+		let isResizing = false;
+		let initialSize = 0;
+		let imageFeedRootSize = 0;
+		let paddingSize = 0;
+		let isVertical = false;
+
+		resizeHandle.addEventListener('mousedown', (e) => {
+			isResizing = true;
+			isVertical = ["left", "right"].includes(feedLocation.value);
+			
+			if (isVertical) {
+				initialSize = e.clientX;
+				imageFeedRootSize = parseFloat(getComputedStyle(imageFeedRoot).width);
+				paddingSize = (imageFeedRootSize - parseFloat(getComputedStyle(imageFeed).width)) * 8;
+			} else {
+				initialSize = e.clientY;
+				imageFeedRootSize = parseFloat(getComputedStyle(imageFeedRoot).height);
+				paddingSize = (imageFeedRootSize - parseFloat(getComputedStyle(imageFeed).height)) * 16;
+			}
+
+
+			[...imageList.querySelectorAll("img")].map((img) => {
+				img.setAttribute("draggable", false);
+			});
+
+			document.addEventListener('mousemove', resizeContainer);
+			document.addEventListener('mouseup', stopResize);
+		});
+
+		function resizeContainer(e) {
+			if (!isResizing) {
+				return;
+			}
+			
+			var newSize = 0;
+
+			if (isVertical) {
+				const deltaX = e.clientX - initialSize;
+				newSize = feedLocation.value == "left" ? imageFeedRootSize + deltaX : imageFeedRootSize - deltaX;
+			} else {
+				const deltaY = e.clientY - initialSize;
+				newSize = feedLocation.value == "top" ? imageFeedRootSize + deltaY : imageFeedRootSize - deltaY;
+			}
+
+			const minSize = getVal("ImageSize", 128);
+			const maxSize = isVertical ?  window.innerWidth : window.innerHeight;
+
+			/* Snap to closest image-size multiple for a cleaner list */
+			if (e.ctrlKey) { 
+				let steps = Math.round(newSize / minSize)
+				let gapSize = parseFloat(getComputedStyle(imageFeedRoot).getPropertyValue("--image-gap-size"));
+				newSize =  steps * minSize;
+				newSize = newSize + paddingSize + (steps * (gapSize + 2));
+			}
+
+			if (newSize >= minSize && newSize <= maxSize) {
+				if (isVertical) {
+					imageFeedRoot.style.width = `max(calc(var(--image-size) + 76px), ${newSize}px, 200px)`;
+
+				} else {
+					imageFeedRoot.style.height = `max(calc(var(--image-size) + 76px), ${newSize}px, 200px)`;
+				}
+			}
+		}
+
+		function stopResize() {
+			isResizing = false;
+			document.removeEventListener('mousemove', resizeContainer);
+			document.removeEventListener('mouseup', stopResize);
+
+			[...imageList.querySelectorAll("img")].map((img) => {
+				img.setAttribute("draggable", true);
+			});
+		}
 	},
 });


### PR DESCRIPTION
- Makes the panel resizable using a bar on the open side
- Slight styling changes
- Removed column amount/image feed size options
- Added image size option
- Grid should auto-adjust based on the panel size and desired image size
- Holding Ctrl while resizing will snap the panel to the current image size * step
- Changed the "Resize Feed" setting text to a Cog emoji
- Use the .div for image items instead of .img to adjust brightness (The image could be smaller than parts of the button due to differing aspect ratios, but the button itself is always the desired image size. 1:1)
- Moved css variables to the new image-feed-root
- Always show the inner feed box

https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/47731506/e7030bfc-3330-4622-9229-ab3695478084

--------
I ended up having free time unexpectedly, so I went ahead and tried to work on some of those suggestions I had.

Doing a draft for now, since I would like feedback on the current changes from another user's perspective, and it's slightly broken in a few ways at the moment. Also pretty messy.
The "right" location settings menu is broken because it's attached to the panel, so width changes from adjusting image size makes it do bad things.

-------
Definitely want
- [ ] Hold shift while changing panel's width to also adjust image size. (This plus the Ctrl + Drag should make it have feature parity with the previous setup, but with a more intuitive way of adjusting.)
- [ ] Rework the settings box to be a "pop-up" that isn't parented to the feed. (Is there a proper way to do this already with something from comfy/litegraph? I know it has pop-ups, but I don't know how adjustable they are, or how I would go about using them.)
- [ ] Fix flickering cursor when resizing too fast.
- [ ] Update Readme with new features.

Nice to have
- [ ] Adjust the panel's width after changing locations and on load so it doesn't snap outward. (Or change it so the images shrink like I wanted to do and allow for the panel to be dragged smaller than image size.)
- [ ] An option to show live previews in the image feed where the next image would be instead of on the prompt thing.
- [ ] Have a little area near the settings/clear/close buttons, that when dragging, shows a preview to snap the panel to a different location. On release, changes the location to it.
- [ ] A switch for descending/ascending images in the "header bar" or in the panel's settings. (These last 2 should allow you to remove those options from the ComfyUI settings to reduce clutter.)
