### PR TITLE
sort workflow items in the load workflow menu

### DIFF
--- a/web/js/workflows.js
+++ b/web/js/workflows.js
@@ -81,6 +81,9 @@ async function saveWorkflow(name, workflow, overwrite) {
 class PysssssWorkflows {
 	async load() {
 		this.workflows = await getWorkflows();
+		if(this.workflows.length) {
+			this.workflows.sort();
+		}
 		this.loadMenu.style.display = this.workflows.length ? "flex" : "none";
 	}
 


### PR DESCRIPTION
Currently the Load workflow menu has its menu shows at random order. 
![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/3213191/26322972-e609-477f-a5b8-38e2bfdc548b)

This PR add sorting so the workflows display in alphabetical order.
![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/3213191/0ddef4af-481f-4c26-bddc-e2983185e4d5)
