### PR TITLE
Fix refresh resetting loader values to default

### DIFF
--- a/web/js/betterCombos.js
+++ b/web/js/betterCombos.js
@@ -143,14 +143,39 @@ app.registerExtension({
 				// Override the option values to check if we should render a menu structure
 				Object.defineProperty(res.widget.options, "values", {
 					get() {
+						let v = values;
+
 						if (submenuSetting.value) {
 							if (!menu) {
 								// Only build the menu once
 								menu = buildMenu(res.widget, values);
 							}
-							return menu;
+							v = menu;
 						}
-						return values;
+
+						const valuesIncludes = v.includes;
+						v.includes = function (searchElement) {
+							const includesFromMenuItems = function (items) {
+								for (const item of items) {
+									if (includesFromMenuItem(item)) {
+										return true;
+									}
+								}
+								return false;
+							}
+							const includesFromMenuItem = function (item) {
+								if (item.submenu) {
+									return includesFromMenuItems(item.submenu.options)
+								} else {
+									return item.content === searchElement.content;
+								}
+							}
+
+							const includes = valuesIncludes.apply(this, arguments) || includesFromMenuItems(this);
+							return includes;
+						}
+
+						return v;
 					},
 					set(v) {
 						// Options are changing (refresh) so reset the menu so it can be rebuilt if required


### PR DESCRIPTION
Proposed fix for https://github.com/pythongosssss/ComfyUI-Custom-Scripts/issues/177

This happens because during refresh it checks if the loader is still in the list of values (https://github.com/comfyanonymous/ComfyUI/blob/7f4725f6b3f72dd8bdb60dae5dd2c3e943263bcf/web/scripts/app.js#L2208-L2209), but this always fails due to it comparing objects (whereas the default loaders compare a string value with list of strings).

The issue only occurs when `widget.options.values[0]` is a file in the root folder. When it is in a subfolder, 
```
if (v?.submenu) {
	// Dont allow selection of submenus
	return;
}
```
prevents the value from being set to the default.