### PR TITLE
Fix autocomplete replacing embedding and lora underscores with spaces

### DIFF
--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -285,6 +285,7 @@ app.registerExtension({
 				words[v] = {
 					text: v,
 					info: () => new EmbeddingInfoDialog(emb).show("embeddings", emb),
+					use_replacer: false,
 				};
 			}
 
@@ -303,6 +304,7 @@ app.registerExtension({
 				words[v] = {
 					text: v,
 					info: () => new LoraInfoDialog(lora).show("loras", lora),
+					use_replacer: false,
 				};
 			}
 

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -576,7 +576,8 @@ export class TextAreaAutoComplete {
 					onclick: () => {
 						this.el.focus();
 						let value = wordInfo.value ?? wordInfo.text;
-						if (TextAreaAutoComplete.replacer) {
+						const use_replacer = wordInfo.use_replacer ?? true;
+						if (TextAreaAutoComplete.replacer && use_replacer) {
 							value = TextAreaAutoComplete.replacer(value);
 						}
 						this.helper.insertAtCursor(value + this.separator, -before.length, wordInfo.caretOffset);


### PR DESCRIPTION
Fixes #165.

Having the `replace _ with space` option enabled will cause embeddings/loras with underscores to be replaced by spaces, which can cause this warning: `warning, embedding:test does not exist, ignoring`, where the correct embedding name changes from `embedding:test_name` to `embedding:test name`.

Fixed by excluding embeddings and loras from using the replacer. I imagine the replacer is mostly meant for tags, so it seems fine for this to always to be disabled for embeddings and loras.