### PR TITLE
Fix uri encoding for preview image

### DIFF
--- a/web/js/betterCombos.js
+++ b/web/js/betterCombos.js
@@ -71,6 +71,13 @@ app.registerExtension({
 			}
 		});
 
+		function encodeRFC3986URIComponent(str) {
+			return encodeURIComponent(str).replace(
+				/[!'()*]/g,
+				(c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+			);
+		}
+
 		// After an element is created for an item, add an image if it has one
 		contextMenuHook["addItem"].push(function (el, menu, [name, value, options]) {
 			if (el && isCustomItem(value) && value?.image && !value.submenu) {
@@ -78,7 +85,7 @@ app.registerExtension({
 				$el("div.pysssss-combo-image", {
 					parent: el,
 					style: {
-						backgroundImage: `url(/pysssss/view/${encodeURIComponent(value.image)})`,
+						backgroundImage: `url(/pysssss/view/${encodeRFC3986URIComponent(value.image)})`,
 					},
 				});
 			}


### PR DESCRIPTION
Fixes https://github.com/pythongosssss/ComfyUI-Custom-Scripts/issues/197.

Problem is that `(` and `)` are not encoded when using `encodeURIComponent`. Have replaced it to use the encoding implementation from
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986 instead which includes encoding the `!`, `'`, `(`, `)`, `*` characters.

Have tested this with the lora loader in chrome/firefox/edge with an image called `!'().jpeg` (no `*` because it cannot be used in windows filenames) and confirmed that it works.