### PR TITLE
image feed deduplication

### DIFF
--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -407,27 +407,6 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 			);
 		}
 
-		function addImageToFeed(href) {
-			const method = feedDirection.value === "newest first" ? "prepend" : "append";
-			imageList[method](
-				$el("div", [
-					$el(
-						"a",
-						{
-							target: "_blank",
-							href,
-							onclick: (e) => {
-								const imgs = [...imageList.querySelectorAll("img")].map((img) => img.getAttribute("src"));
-								lightbox.show(imgs, imgs.indexOf(href));
-								e.preventDefault();
-							},
-						},
-						[$el("img", { src: href })]
-					),
-				])
-			);
-		}
-
 		imageFeed.append(
 			$el("div.pysssss-image-feed-menu", [
 				$el("section.sizing-menu", {}, [

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -483,7 +483,7 @@ app.registerExtension({
 										seenImages.set(hexHash, true);
 										addImageToFeed(href);
 									}
-								}). catch((err) => {
+								}).catch((err) => {
 									// fall back to default behavior
 									console.error(err);
 									addImageToFeed(href);

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -535,10 +535,7 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 								addImageToFeed(href);
 							}
 							img.onload = () => {
-								console.log(`... (${img.width}x${img.height}) fetching image took ${performance.now() - start} milliseconds`);
-
 								// redraw the image onto a canvas to strip metadata (resize if performance mode)
-								let start = performance.now();
 								let imgCanvas = document.createElement("canvas");
 								let imgScalar = deduplicateFeed.value;
 								imgCanvas.width = imgScalar * img.width;
@@ -546,11 +543,7 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 
 								let imgContext = imgCanvas.getContext("2d");
 								imgContext.drawImage(img, 0, 0, imgCanvas.width, imgCanvas.height);
-								console.log(`... (${imgCanvas.width}x${imgCanvas.height}) drawing took ${performance.now() - start} milliseconds`);
-
-								start = performance.now();
 								const data = imgContext.getImageData(0, 0, imgCanvas.width, imgCanvas.height);
-								console.log(`... (${imgCanvas.width}x${imgCanvas.height}) getting data took ${performance.now() - start} milliseconds`);
 
 								// calculate fast hash of the image data
 								start = performance.now();
@@ -558,13 +551,6 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 								for (const b of data.data) {
 									hash = ((hash << 5) - hash) + b;
 								}
-								console.log(`... (${imgCanvas.width}x${imgCanvas.height}) fast hashing took ${performance.now() - start} milliseconds: ${hash}`);
-
-								// calculate slow hash
-								start = performance.now();
-								let strippedImgB64 = imgCanvas.toDataURL("image/png");
-								let slowHash = Array.from(strippedImgB64).reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0);
-								console.log(`... (${imgCanvas.width}x${imgCanvas.height}) slow hashing took ${performance.now() - start} milliseconds: ${slowHash}`);
 
 								// don't include time to add image to feed
 								console.log("%c[🐍 pysssss]", "color: limegreen", `Image deduplication (${imgCanvas.width}x${imgCanvas.height}) took ${performance.now() - startTime}ms: ${fingerprint}`);

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -208,6 +208,7 @@ app.registerExtension({
 	name: "pysssss.ImageFeed",
 	setup() {
 		let visible = true;
+		const seenImages = new Map();
 		const showButton = $el("button.comfy-settings-btn", {
 			textContent: "🖼️",
 			style: {
@@ -307,6 +308,13 @@ app.registerExtension({
 					]),
 				]);
 			},
+		});
+
+		const deduplicateFeed = app.ui.settings.addSetting({
+			id: "pysssss.ImageFeed.Deduplication",
+			name: "🐍 Image Feed Deduplication",
+			defaultValue: false,
+			type: "boolean"
 		});
 
 		const clearButton = $el("button.pysssss-image-feed-btn.clear-btn", {
@@ -416,6 +424,14 @@ app.registerExtension({
 				}
 
 				for (const src of detail.output.images) {
+					if (deduplicateFeed.value) {
+						// deduplicate the feed by ignoring images with the same filename/type/subfolder
+						const fingerprint = JSON.stringify({filename: src.filename, type: src.type, subfolder: src.subfolder});
+						if (seenImages.has(fingerprint))
+							continue;
+						seenImages.set(fingerprint, true);
+					}
+
 					const href = `./view?filename=${encodeURIComponent(src.filename)}&type=${
 						src.type
 					}&subfolder=${encodeURIComponent(src.subfolder)}&t=${+new Date()}`;

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -523,7 +523,6 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 					// but when deduplication is disabled, this value is "0"
 					if (deduplicateFeed.value > 0) {
 						// deduplicate by ignoring images with the same filename/type/subfolder
-						let startTime = performance.now();
 						const fingerprint = JSON.stringify({ filename: src.filename, type: src.type, subfolder: src.subfolder });
 						if (seenImages.has(fingerprint)) {
 							// NOOP: image is a duplicate
@@ -546,14 +545,10 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 								const data = imgContext.getImageData(0, 0, imgCanvas.width, imgCanvas.height);
 
 								// calculate fast hash of the image data
-								start = performance.now();
 								let hash = 0;
 								for (const b of data.data) {
 									hash = ((hash << 5) - hash) + b;
 								}
-
-								// don't include time to add image to feed
-								console.log("%c[🐍 pysssss]", "color: limegreen", `Image deduplication (${imgCanvas.width}x${imgCanvas.height}) took ${performance.now() - startTime}ms: ${fingerprint}`);
 
 								// add image to feed if we've never seen the hash before
 								if (seenImages.has(hash)) {

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -341,6 +341,27 @@ app.registerExtension({
 			columnInput.value = v;
 		}
 
+		function addImageToFeed(href) {
+			const method = feedDirection.value === "newest first" ? "prepend" : "append";
+			imageList[method](
+				$el("div", [
+					$el(
+						"a",
+						{
+							target: "_blank",
+							href,
+							onclick: (e) => {
+								const imgs = [...imageList.querySelectorAll("img")].map((img) => img.getAttribute("src"));
+								lightbox.show(imgs, imgs.indexOf(href));
+								e.preventDefault();
+							},
+						},
+						[$el("img", { src: href })]
+					),
+				])
+			);
+		}
+
 		imageFeed.append(
 			$el("div.pysssss-image-feed-menu", [
 				$el("section.sizing-menu", {}, [
@@ -424,36 +445,21 @@ app.registerExtension({
 				}
 
 				for (const src of detail.output.images) {
-					if (deduplicateFeed.value) {
-						// deduplicate the feed by ignoring images with the same filename/type/subfolder
-						const fingerprint = JSON.stringify({filename: src.filename, type: src.type, subfolder: src.subfolder});
-						if (seenImages.has(fingerprint))
-							continue;
-						seenImages.set(fingerprint, true);
-					}
-
 					const href = `./view?filename=${encodeURIComponent(src.filename)}&type=${
 						src.type
 					}&subfolder=${encodeURIComponent(src.subfolder)}&t=${+new Date()}`;
 
-					const method = feedDirection.value === "newest first" ? "prepend" : "append";
-					imageList[method](
-						$el("div", [
-							$el(
-								"a",
-								{
-									target: "_blank",
-									href,
-									onclick: (e) => {
-										const imgs = [...imageList.querySelectorAll("img")].map((img) => img.getAttribute("src"));
-										lightbox.show(imgs, imgs.indexOf(href));
-										e.preventDefault();
-									},
-								},
-								[$el("img", { src: href })]
-							),
-						])
-					);
+					if (deduplicateFeed.value) {
+						// deduplicate by ignoring images with the same filename/type/subfolder
+						const fingerprint = JSON.stringify({filename: src.filename, type: src.type, subfolder: src.subfolder});
+						if (seenImages.has(fingerprint)) {
+							// NOOP: image is a duplicate
+						} else {
+							seenImages.set(fingerprint, true);
+						}
+					} else {
+						addImageToFeed(href);
+					}
 				}
 			}
 		});

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -438,20 +438,19 @@ app.registerExtension({
 
 		api.addEventListener("executed", ({ detail }) => {
 			if (visible && detail?.output?.images) {
-				if(detail.node?.includes?.(":")) {
+				if (detail.node?.includes?.(":")) {
 					// Ignore group nodes
 					const n = app.graph.getNodeById(detail.node.split(":")[0]);
-					if(n?.getInnerNodes) return;
+					if (n?.getInnerNodes) return;
 				}
 
 				for (const src of detail.output.images) {
-					const href = `./view?filename=${encodeURIComponent(src.filename)}&type=${
-						src.type
-					}&subfolder=${encodeURIComponent(src.subfolder)}&t=${+new Date()}`;
+					const href = `./view?filename=${encodeURIComponent(src.filename)}&type=${src.type
+						}&subfolder=${encodeURIComponent(src.subfolder)}&t=${+new Date()}`;
 
 					if (deduplicateFeed.value) {
 						// deduplicate by ignoring images with the same filename/type/subfolder
-						const fingerprint = JSON.stringify({filename: src.filename, type: src.type, subfolder: src.subfolder});
+						const fingerprint = JSON.stringify({ filename: src.filename, type: src.type, subfolder: src.subfolder });
 						if (seenImages.has(fingerprint)) {
 							// NOOP: image is a duplicate
 						} else {

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -313,6 +313,11 @@ app.registerExtension({
 		const deduplicateFeed = app.ui.settings.addSetting({
 			id: "pysssss.ImageFeed.Deduplication",
 			name: "🐍 Image Feed Deduplication",
+			tooltip: `Ensures unique images in the image feed but at the cost of CPU-bound performance impact \
+(from hundreds of milliseconds to seconds per image, depending on byte size).
+
+For workflows that produce duplicate images, turning this setting on may yield overall client-side performance improvements \
+by reducing the number of images in the feed.`,
 			defaultValue: false,
 			type: "boolean"
 		});

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -456,6 +456,30 @@ app.registerExtension({
 							// NOOP: image is a duplicate
 						} else {
 							seenImages.set(fingerprint, true);
+
+							// deduplicate by ignoring images with the same content
+							let img = $el("img", { src: href })
+							img.onload = () => {
+								// redraw the image onto a canvas to strip metadata
+								var imgCanvas = document.createElement("canvas");
+								imgCanvas.width = img.width;
+								imgCanvas.height = img.height;
+
+								var imgContext = imgCanvas.getContext("2d");
+								imgContext.drawImage(img, 0, 0, img.width, img.height);
+
+								var strippedImgB64 = imgCanvas.toDataURL("image/png");
+								if (seenImages[strippedImgB64]) {
+									// NOOP: image is a duplicate
+								} else {
+									addImageToFeed(href);
+									seenImages[strippedImgB64] = true;
+								}
+							}
+							img.onerror = () => {
+								// fall back to default behavior
+								addImageToFeed(href);
+							}
 						}
 					} else {
 						addImageToFeed(href);


### PR DESCRIPTION
(Thank you for your work!)

**Problem**
Some nodes can generate the same image for consecutive generations, which clutters the image feed with duplicate images:

![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/83140/59fcb350-9c53-4e09-a56e-c1cfdc617815)

There are two categories of duplicate images to consider, here:
1. Two images point to the same file on server.
2. Two images look the same but are stored differently on server, potentially with unique metadata.

**Solution**
1. Memoize the image `src` metadata (filename/type/subfolder) and hash (sans metadata).
2. Prevent addition to the feed if we've seen either the metadata or the hash before.

**Performance**
![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/83140/80edfab0-c5c4-4b36-8fd9-3eb59265487d)
_(tested on Ryzen 9 3950X w/ 64 MB RAM, running on local instance of comfy)_

~69% of the performance hit is due the additional drawing on an invisible canvas, in order to get image data without the metadata. For workflows yielding duplicates, the cost is offset by the cost-saving from not adding duplicate images to the feed (which would require canvas renders). An optimization idea for the future is to strip the metadata section of the original image (ref: [PNG eXIf spec](http://ftp-osl.osuosl.org/pub/libpng/documents/pngext-1.5.0.html#C.eXIf)), which must be a faster operation.

To opt in to this feature, turn it on in settings (off by default):
![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/83140/44f15f58-a9b1-4a8e-9e88-afed1ddaa2ad)
