### PR TITLE
Fix relative import paths in autocompleter.js

### DIFF
--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -1,7 +1,7 @@
 import { app } from "../../../scripts/app.js";
 import { ComfyWidgets } from "../../../scripts/widgets.js";
-import { api } from "../../../../scripts/api.js";
-import { $el, ComfyDialog } from "../../../../scripts/ui.js";
+import { api } from "../../../scripts/api.js";
+import { $el, ComfyDialog } from "../../../scripts/ui.js";
 import { TextAreaAutoComplete } from "./common/autocomplete.js";
 import { ModelInfoDialog } from "./common/modelInfoDialog.js";
 import { LoraInfoDialog } from "./modelInfo.js";


### PR DESCRIPTION
Looks like there are a couple of imports that attempt to go up one directory higher than they should.

Was running into a stubborn issue with this file where it would not be loaded by ComfyUI when accessing Comfy hosted in a subdirectory using a reverse proxy (e.g., [http://example.com/comfy/]()). When hosted at the root, the extra `../` is silently ignored and all appears well, but when running Comfy in a subdirectory, it ends up going outside of the subdirectory and causes these imports to fail, causing the autocompleter extension to fail.

Should solve #179, as I was seeing the same issue.