### PR TITLE
Fix a bug in notify, line is "if unique_id and extra_pnginfo and…

### DIFF
--- a/py/show_text.py
+++ b/py/show_text.py
@@ -19,12 +19,24 @@ class ShowText:
 
     CATEGORY = "utils"
 
-    def notify(self, text, unique_id = None, extra_pnginfo=None):
-        if unique_id and extra_pnginfo and "workflow" in extra_pnginfo[0]:
-            workflow = extra_pnginfo[0]["workflow"]
-            node = next((x for x in workflow["nodes"] if str(x["id"]) == unique_id[0]), None)
-            if node:
-                node["widgets_values"] = [text]
+    def notify(self, text, unique_id=None, extra_pnginfo=None):
+        if unique_id is not None and extra_pnginfo is not None:
+            if not isinstance(extra_pnginfo, list):
+                print("Error: extra_pnginfo is not a list")
+            elif (
+                not isinstance(extra_pnginfo[0], dict)
+                or "workflow" not in extra_pnginfo[0]
+            ):
+                print("Error: extra_pnginfo[0] is not a dict or missing 'workflow' key")
+            else:
+                workflow = extra_pnginfo[0]["workflow"]
+                node = next(
+                    (x for x in workflow["nodes"] if str(x["id"]) == str(unique_id[0])),
+                    None,
+                )
+                if node:
+                    node["widgets_values"] = [text]
+
         return {"ui": {"text": text}, "result": (text,)}
 
 


### PR DESCRIPTION
Fix a bug in **notify**, line is `if unique_id and extra_pnginfo and workflow in extra_pnginfo[0]`, Error is `TypeError: argument of type NoneType is not iterable`.

When I upgraded comfyui to the latest version yesterday, when executing the workflow through the API, this error prevented the execution of the program. Here is a simple workflow I put together to reproduce this error:
```
curl --request POST \
  --url http://127.0.0.1:8199/prompt \
  --header 'content-type: application/json' \
  --header 'user-agent: vscode-restclient' \
  --data '{"prompt":{"10":{"inputs":{"text":["12",0]},"class_type":"ShowText|pysssss","_meta":{"title":"Show Text 🐍"}},"12":{"inputs":{"text":"hello world!"},"class_type":"ttN text","_meta":{"title":"text"}}}}'
```