### PR TITLE
Fix TypeError(string indices must be integers) in populate_items when…

### DIFF
--- a/py/better_combos.py
+++ b/py/better_combos.py
@@ -74,6 +74,7 @@ async def get_examples(request):
 
 
 def populate_items(names, type):
+    new_names = []
     for idx, item_name in enumerate(names):
 
         file_name = os.path.splitext(item_name)[0]
@@ -91,11 +92,14 @@ def populate_items(names, type):
                 item_image = f"{file_name}.{ext}"
                 break
 
-        names[idx] = {
+        new_names.append({
             "content": item_name,
             "image": f"{type}/{item_image}" if has_image else None,
-        }
-    names.sort(key=lambda i: i["content"].lower())
+        })
+    
+    new_names.sort(key=lambda i: i["content"].lower())
+    names.clear()
+    names.extend(new_names)
 
 
 class LoraLoaderWithImages(LoraLoader):


### PR DESCRIPTION
I created some soft-links for checkpoints from hungging local hub. When the soft-link is broken, the TypeError raise on Line100 in the file(py/better_combos.py). Because names[idx] is a string when file_path is None.