### PR TITLE
Fix display type for image feed when toggled

### DIFF
--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -428,7 +428,7 @@ app.registerExtension({
 			imageList
 		);
 		showButton.onclick = () => {
-			imageFeed.style.display = "block";
+			imageFeed.style.display = "flex";
 			showButton.style.display = "none";
 			if (showMenuButton) showMenuButton.enabled = false;
 


### PR DESCRIPTION
Should default to flex for visibility, since the menu and list children assume that they're flex items.