### PR TITLE
snap group to grid if SHIFT is down or "always snap to grid" is enabled

### DIFF
--- a/web/js/snapToGrid.js
+++ b/web/js/snapToGrid.js
@@ -52,6 +52,87 @@ const ext = {
 
 			return configure.apply(this, arguments);
 		};
+
+		// keep states related to the drag-and-drop of groups
+		let dndState = {
+			group: null,
+			ctrlDown: false,
+		};
+
+		// when ctrl is pressed, we default to the original behavior of smooth translation w/o affecting the nodes in the group
+		window.addEventListener("keydown", (e) => {
+			// check whether ctrl is pressed
+			if (e.ctrlKey) {
+				dndState.ctrlDown = true;
+			}
+		});
+
+		window.addEventListener("keyup", (e) => {
+			// check whether ctrl is released
+			if (!e.ctrlKey) {
+				dndState.ctrlDown = false;
+			}
+		});
+
+		// capture the drag-and-drop event for groups
+		const onMouseDown = LGraphCanvas.prototype.onMouseDown;
+		LGraphCanvas.prototype.onMouseDown = function (e) {
+			const r = onMouseDown?.apply(this, arguments);
+			const group = this.graph.getGroupOnPos(this.graph_mouse[0], this.graph_mouse[1]);
+			dndState.group = group;
+			dndState.origMouseX = this.graph_mouse[0];
+			dndState.origMouseY = this.graph_mouse[1];
+			return r;
+		};
+
+		const onMouseUp = LGraphCanvas.prototype.onMouseUp;
+		LGraphCanvas.prototype.onMouseUp = function (e) {
+			const r = onMouseUp?.apply(this, arguments);
+			dndState.group = null;
+			return r;
+		};
+
+		// override the drawGroups function to snap the group to the grid
+		const origDrawGroups = LGraphCanvas.prototype.drawGroups;
+		LGraphCanvas.prototype.drawGroups = function () {		
+			const snapToGrid = app.shiftDown || setting?.value;
+			const mouseX = this.graph_mouse[0];
+			const mouseY = this.graph_mouse[1];
+			let shiftX = 0;
+			let shiftY = 0;
+			if (snapToGrid && !dndState.ctrlDown && dndState.group) {
+				// discretize the canvas position to the nearest snappable coordinate,
+				// but account for the diff between mouse and group positions
+				const g = dndState.group;
+				shiftX = LiteGraph.CANVAS_GRID_SIZE * Math.round((mouseX - g.pos[0]) / LiteGraph.CANVAS_GRID_SIZE);
+				shiftY = LiteGraph.CANVAS_GRID_SIZE * Math.round((mouseY - g.pos[1]) / LiteGraph.CANVAS_GRID_SIZE);
+
+				let x = LiteGraph.CANVAS_GRID_SIZE * Math.round((mouseX) / LiteGraph.CANVAS_GRID_SIZE);
+				let y = LiteGraph.CANVAS_GRID_SIZE * Math.round((mouseY) / LiteGraph.CANVAS_GRID_SIZE);
+				x -= shiftX;
+				y -= shiftY;
+
+				// update group position (`move()` does not yield smooth translation across canvas)
+				const dx = g.pos[0] - x;
+				const dy = g.pos[1] - y;
+				g.pos[0] = x;
+				g.pos[1] = y;
+
+				// translate all nodes in group, translate them by dx, dy
+				for (const node of g._nodes) {
+					node.pos[0] -= dx;
+					node.pos[1] -= dy;
+				}
+
+				// ensure the group bounds are snapped to the grid (e.g., when resizing the group)
+				// caveat: this may resize the group to snap the bounds to the grid, even if the group is not being resized but only being moved
+				g.size[0] = LiteGraph.CANVAS_GRID_SIZE * Math.round(g.size[0] / LiteGraph.CANVAS_GRID_SIZE);
+				g.size[1] = LiteGraph.CANVAS_GRID_SIZE * Math.round(g.size[1] / LiteGraph.CANVAS_GRID_SIZE);
+
+			}
+
+			return origDrawGroups.apply(this, arguments);
+		};
 	},
 };
 

--- a/web/js/snapToGrid.js
+++ b/web/js/snapToGrid.js
@@ -100,7 +100,7 @@ const ext = {
 			const mouseY = this.graph_mouse[1];
 			let shiftX = 0;
 			let shiftY = 0;
-			if (snapToGrid && !dndState.ctrlDown && dndState.group) {
+			if (snapToGrid && dndState.group) {
 				// discretize the canvas position to the nearest snappable coordinate,
 				// but account for the diff between mouse and group positions
 				const g = dndState.group;
@@ -119,9 +119,12 @@ const ext = {
 				g.pos[1] = y;
 
 				// translate all nodes in group, translate them by dx, dy
-				for (const node of g._nodes) {
-					node.pos[0] -= dx;
-					node.pos[1] -= dy;
+				// but don't do this when ctrl is pressed
+				if (!dndState.ctrlDown) {
+					for (const node of g._nodes) {
+						node.pos[0] -= dx;
+						node.pos[1] -= dy;
+					}
 				}
 
 				// ensure the group bounds are snapped to the grid (e.g., when resizing the group)


### PR DESCRIPTION
This PR addresses  #198.

# Problem
Groups do not snap like nodes do, which makes maintaining neatly aligned nodes extremely difficult/cumbersome.

# Solution
Make groups behave like nodes, by snapping their position and size to the grid:

https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/83140/65503939-e994-41bc-b0f8-3521307ff532

When "always snap to grid" is off, holding SHIFT enables snapping for groups, as is the behavior for nodes.
Snapping also works when pressing CTRL while dragging a group to release the "tether" from the group to its nodes.