### PR TITLE
Improve image loader validation to only consider model file

### DIFF
--- a/py/better_combos.py
+++ b/py/better_combos.py
@@ -106,6 +106,17 @@ class LoraLoaderWithImages(LoraLoader):
         populate_items(names, "loras")
         return types
 
+    @classmethod
+    def VALIDATE_INPUTS(s, lora_name):
+        types = super().INPUT_TYPES()
+        names = types["required"]["lora_name"][0]
+
+        name = lora_name["content"]
+        if name in names:
+            return True
+        else:
+            return f"Lora not found: {name}"
+
     def load_lora(self, **kwargs):
         kwargs["lora_name"] = kwargs["lora_name"]["content"]
         return super().load_lora(**kwargs)
@@ -118,6 +129,17 @@ class CheckpointLoaderSimpleWithImages(CheckpointLoaderSimple):
         names = types["required"]["ckpt_name"][0]
         populate_items(names, "checkpoints")
         return types
+
+    @classmethod
+    def VALIDATE_INPUTS(s, ckpt_name):
+        types = super().INPUT_TYPES()
+        names = types["required"]["ckpt_name"][0]
+
+        name = ckpt_name["content"]
+        if name in names:
+            return True
+        else:
+            return f"Checkpoint not found: {name}"
 
     def load_checkpoint(self, **kwargs):
         kwargs["ckpt_name"] = kwargs["ckpt_name"]["content"]


### PR DESCRIPTION
Fixes #259.

The value of `lora_name` and `ckpt_name` is a dict containing the location of both the model and preview image, e.g:
`{"content": "path/to/model", "image": "path/to/image"}`
so the default validation is checking that not only the model exists, but the image exists as well. A change in the path of the image (e.g. going from `jpg`->`png` or having it deleted) should not affect the validation, but currently does.

Tested this fix by:
  1. Selecting a model in the loader
  2. Renaming the image file
  3. Confirming running the prompt no longer raises a validation error