### PR TITLE
Save and restore the transformation matrix during exporting

### DIFF
--- a/web/js/workflowImage.js
+++ b/web/js/workflowImage.js
@@ -37,6 +37,7 @@ class WorkflowImage {
 			width: app.canvas.canvas.width,
 			height: app.canvas.canvas.height,
 			offset: app.canvas.ds.offset,
+			transform: app.canvas.canvas.getContext('2d').getTransform(), // Save the original transformation matrix
 		};
 	}
 
@@ -45,6 +46,7 @@ class WorkflowImage {
 		app.canvas.canvas.width = this.state.width;
 		app.canvas.canvas.height = this.state.height;
 		app.canvas.ds.offset = this.state.offset;
+		app.canvas.canvas.getContext('2d').setTransform(this.state.transform); // Reapply the original transformation matrix
 	}
 
 	updateView(bounds) {


### PR DESCRIPTION
Save and restore the transformation matrix. This ensures that visual properties and transformations are maintained across operations that require resizing or modifying the canvas. The update resolves issues related to unintended scaling and transformation resets when the canvas dimensions are programmatically changed.

Explanation: This line changes the canvas's property:
```
app.canvas.canvas.width = app.canvas.canvas.width;
```
This might at first lance seem like it should have no effect, but it actually does due to how the canvas element handles changes to its width and height properties.
