### PR TITLE
fix: fetch the image type only if there's a possibility of a video type.

### DIFF
--- a/web/js/common/modelInfoDialog.js
+++ b/web/js/common/modelInfoDialog.js
@@ -249,8 +249,9 @@ export class ModelInfoDialog extends ComfyDialog {
 					})
 				);
 
-				if (info.images?.length) {
-					this.img.src = info.images[0].url;
+				const preview = info.images.find((i) => i.type === "image");
+				if (preview) {
+					this.img.src = preview.url;
 					this.img.style.display = "";
 
 					this.imgSave = $el("button", {


### PR DESCRIPTION
![image](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/assets/1059327/1c2d7a4e-1a77-4c73-9306-e9067a3850ec)
Fix the broken image issue in Model Info panel.
