### PR TITLE
Fix autocomplete opening on unrelated keypresses

### DIFF
--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -471,7 +471,7 @@ export class TextAreaAutoComplete {
 					this.#hide();
 					break;
 			}
-		} else if (e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "ArrowLeft" || e.key === "ArrowRight") {
+		} else if (e.key.length > 1 && e.key != "Delete" && e.key != "Backspace") {
 			return;
 		}
 		if (!e.defaultPrevented) {


### PR DESCRIPTION
Autocomplete pops up when pressing shift, control, home, end, etc.  I really wanted the feature, though - now it shows only when the key value is <= 1 (e.g. any character entry `d`, `=`, `9`), or the key was backspace/delete.