### PR TITLE
ShowText populate fix

### DIFF
--- a/web/js/showText.js
+++ b/web/js/showText.js
@@ -14,10 +14,9 @@ app.registerExtension({
 					this.widgets.length = 1;
 				}
 
-				const v = [...text];
-				if (!v[0]) {
-					v.shift();
-				}
+				const lastText = text.at(-1);
+				const v = lastText !== undefined ? [lastText] : [];
+				
 				for (const list of v) {
 					const w = ComfyWidgets["STRING"](this, "text", ["STRING", { multiline: true }], app).widget;
 					w.inputEl.readOnly = true;


### PR DESCRIPTION
This implementation will fix the issue of cached texts creating multiple duplicate widgets sometimes when loading a workflow. I might be missing the reason it was done the way it was originally so please review!