### PR TITLE
Fix lightbox loading position

### DIFF
--- a/web/js/common/lightbox.css
+++ b/web/js/common/lightbox.css
@@ -49,7 +49,9 @@
 }
 
 .pysssss-lightbox-link {
-	display: inline-block;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	position: relative;
 }
 

--- a/web/js/common/spinner.css
+++ b/web/js/common/spinner.css
@@ -1,6 +1,6 @@
 .pysssss-lds-ring {
 	display: inline-block;
-	position: relative;
+	position: absolute;
 	width: 80px;
 	height: 80px;
 }


### PR DESCRIPTION
#### Issue
When scrolling through images in the Image Feed, there is a brief jitter as images are loaded.

#### Cause
The loading spinner is an inline sibling element of the image element.

#### Solution
Use absolute positioning on the spinner root element, relative to the containing pysssss-lightbox-link element.  Use flex to centre the lightbox contents.