### PR TITLE
adjust Image feed width and height

### DIFF
--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -33,8 +33,8 @@ $el("style", {
 	}
 	.pysssss-image-feed--left, .pysssss-image-feed--right {
 		top: 0;
-		height: 100vh;
-		min-width: 200px;
+		height: 80vh;
+		min-width: 120px;
 		max-width: calc(var(--max-size, 10) * 1vw);
 	}
 	.comfyui-body-left .pysssss-image-feed--left, .comfyui-body-right .pysssss-image-feed--right {


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/148d733b-998a-4769-95c2-666f11692124)

After:
![fixed](https://github.com/user-attachments/assets/67e9173f-6222-41c2-8987-2dc4a2998e78)

I like to use image feed like this, so I think it is better when it is on left to reduce min width to be 120 instead of 200 and the height to 80 instead of 100 so it doesn't hide comfy management workflow and it doesn't waste space when we use one column with min size of the image.