### PR TITLE
fix: The return of ctx is missing in the overriding of LiteGraph.ContextMenu

### DIFF
--- a/web/js/contextMenuHook.js
+++ b/web/js/contextMenuHook.js
@@ -83,7 +83,7 @@ app.registerExtension({
 			}
 
 			triggerCallbacks("ctor", () => [values, options]);
-			ctxMenu.call(this, values, options);
+			return ctxMenu.call(this, values, options);
 		};
 		LiteGraph.ContextMenu.prototype = ctxMenu.prototype;
 	},


### PR DESCRIPTION
Fix for the issue where the ContextMenu object created by the overridden ContextMenu constructor cannot be accessed