### PR TITLE
Fix PresetText node

### DIFF
--- a/web/js/presetText.js
+++ b/web/js/presetText.js
@@ -63,8 +63,10 @@ app.registerExtension({
 		}
 	},
 	registerCustomNodes() {
-		class PresetTextNode {
+		class PresetTextNode extends LiteGraph.LGraphNode {
 			constructor() {
+				super();
+				this.title = "Preset Text 🐍";
 				this.isVirtualNode = true;
 				this.serialize_widgets = true;
 				this.addOutput("text", "STRING");


### PR DESCRIPTION
Fixes:

- #331
- #336 

Because of Comfy-Org/ComfyUI_frontend#667 (Comfy-Org/litegraph.js#98), it's necessary to subclass nodes to inherit `LGraphNode` properties.
