### PR TITLE
Fix: fix transparent background when saving the workflow

### DIFF
--- a/web/js/workflowImage.js
+++ b/web/js/workflowImage.js
@@ -50,10 +50,12 @@ class WorkflowImage {
 	}
 
 	updateView(bounds) {
+		const scale = window.devicePixelRatio || 1;
 		app.canvas.ds.scale = 1;
-		app.canvas.canvas.width = bounds[2] - bounds[0];
-		app.canvas.canvas.height = bounds[3] - bounds[1];
-		app.canvas.ds.offset = [-bounds[0], -bounds[1]];
+		app.canvas.canvas.width = (bounds[2] - bounds[0]) * scale;
+		app.canvas.canvas.height = (bounds[3] - bounds[1]) * scale;
+		app.canvas.ds.offset = [-bounds[0] * scale, -bounds[1] * scale];
+		app.canvas.canvas.getContext("2d").setTransform(scale, 0, 0, scale, 0, 0);
 	}
 
 	getDrawTextConfig(_, widget) {


### PR DESCRIPTION
### Issue
When saving the workflow as a PNG, a white area appears (bug). #359 

### Cause
The dependency library has adjusted the size of background image on high DPI devices, as shown in the image below.
![image](https://github.com/user-attachments/assets/d90ca822-9a36-446a-9658-2d5ef8b19365)


### Solution
One of the solution is to adjust the size of canvas when saving images(modify the function `updateView`).

(This issue can also be fixed by temporarily setting window.devicePixelRatio to 1, but it may not seem like a good idea.)