### PR TITLE
Fix snap guide enable condition

### DIFF
--- a/web/js/snapToGridGuide.js
+++ b/web/js/snapToGridGuide.js
@@ -97,11 +97,16 @@ const ext = {
 			}
 		});
 
+		const alwaysSnapToGrid = () =>
+			app.ui.settings.getSettingValue("pysssss.SnapToGrid", /* default=*/ false);
+		const snapToGridEnabled = () =>
+			app.shiftDown || alwaysSnapToGrid();
+
 		// Override drag-and-drop behavior to show orthogonal guide lines around selected node(s) and preview of where the node(s) will be placed
-		const origDrawNode = LGraphCanvas.prototype.drawNode
+		const origDrawNode = LGraphCanvas.prototype.drawNode;
 		LGraphCanvas.prototype.drawNode = function (node, ctx) {
 			const enabled = guide_config.lines.enabled || guide_config.block.enabled;
-			if (enabled && app.shiftDown && this.node_dragged && node.id in this.selected_nodes) {
+			if (enabled && this.node_dragged && node.id in this.selected_nodes && snapToGridEnabled()) {
 				// discretize the canvas into grid
 				let x = LiteGraph.CANVAS_GRID_SIZE * Math.round(node.pos[0] / LiteGraph.CANVAS_GRID_SIZE);
 				let y = LiteGraph.CANVAS_GRID_SIZE * Math.round(node.pos[1] / LiteGraph.CANVAS_GRID_SIZE);


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1181#issuecomment-2433369678

Follow-up of https://github.com/pythongosssss/ComfyUI-Custom-Scripts/pull/370

Previously `app.shiftDown` directly determines whether snapToGrid is enabled or not, but now it also depends on whether always snap to grid setting is enabled. This PR fixes the enable condition.