### PR TITLE
fix: the offset should not be multiplied by the scale

### DIFF
--- a/web/js/workflowImage.js
+++ b/web/js/workflowImage.js
@@ -54,7 +54,7 @@ class WorkflowImage {
 		app.canvas.ds.scale = 1;
 		app.canvas.canvas.width = (bounds[2] - bounds[0]) * scale;
 		app.canvas.canvas.height = (bounds[3] - bounds[1]) * scale;
-		app.canvas.ds.offset = [-bounds[0] * scale, -bounds[1] * scale];
+		app.canvas.ds.offset = [-bounds[0], -bounds[1]];
 		app.canvas.canvas.getContext("2d").setTransform(scale, 0, 0, scale, 0, 0);
 	}
 


### PR DESCRIPTION
This pull request is to fix the offset problem caused by #375. 

#375 fixed the problem of exporting images on high DPI devices by multiplying the image `width`, `height` and `transform` by the `devicePixelRatio`. But it also multiplied the `offset` by the `devicePixelRatio`, which caused some workflows with large offsets to not be correctly displayed in the center of the exported image.