### PR TITLE
provide refreshComboInNodes

### DIFF
--- a/web/js/workflows.js
+++ b/web/js/workflows.js
@@ -268,12 +268,13 @@ app.registerExtension({
 			parent: document.head,
 		});
 	},
+
+	async refreshComboInNodes() {
+		workflows.load()
+	},
+	
 	async setup() {
 		workflows = new PysssssWorkflows();
-		app.refreshComboInNodes = function () {
-			workflows.load();
-			refreshComboInNodes.apply(this, arguments);
-		};
 
 		const comfyDefault = "[ComfyUI Default]";
 		const defaultWorkflow = app.ui.settings.addSetting({


### PR DESCRIPTION
refreshComboInNodes is now an invoked extension hook, so instead of hijacking app.refreshComboInNodes, you can just provide the method and reduce incompatibility issues.

(Discovered because I was doing the same thing in cg-controller, and our two hijacks weren't playing nicely!)