### PR TITLE
Improve usability of Autocomplete

### DIFF
--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -6,6 +6,8 @@ import { TextAreaAutoComplete } from "./common/autocomplete.js";
 import { ModelInfoDialog } from "./common/modelInfoDialog.js";
 import { LoraInfoDialog } from "./modelInfo.js";
 
+const MAX_ROW_COUNT = 50;
+
 function parseCSV(csvText) {
 	const rows = [];
 	const delimiter = ",";
@@ -525,7 +527,7 @@ app.registerExtension({
 		TextAreaAutoComplete.insertOnTab = localStorage.getItem(id + ".InsertOnTab") !== "false";
 		TextAreaAutoComplete.insertOnEnter = localStorage.getItem(id + ".InsertOnEnter") !== "false";
 		TextAreaAutoComplete.lorasEnabled = localStorage.getItem(id + ".ShowLoras") === "true";
-		TextAreaAutoComplete.suggestionCount = +localStorage.getItem(id + ".SuggestionCount") || 20;
+		TextAreaAutoComplete.suggestionCount = +localStorage.getItem(id + ".SuggestionCount") || MAX_ROW_COUNT;
 	},
 	setup() {
 		async function addEmbeddings() {

--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -6,8 +6,6 @@ import { TextAreaAutoComplete } from "./common/autocomplete.js";
 import { ModelInfoDialog } from "./common/modelInfoDialog.js";
 import { LoraInfoDialog } from "./modelInfo.js";
 
-const MAX_ROW_COUNT = 50;
-
 function parseCSV(csvText) {
 	const rows = [];
 	const delimiter = ",";
@@ -527,7 +525,7 @@ app.registerExtension({
 		TextAreaAutoComplete.insertOnTab = localStorage.getItem(id + ".InsertOnTab") !== "false";
 		TextAreaAutoComplete.insertOnEnter = localStorage.getItem(id + ".InsertOnEnter") !== "false";
 		TextAreaAutoComplete.lorasEnabled = localStorage.getItem(id + ".ShowLoras") === "true";
-		TextAreaAutoComplete.suggestionCount = +localStorage.getItem(id + ".SuggestionCount") || MAX_ROW_COUNT;
+		TextAreaAutoComplete.suggestionCount = +localStorage.getItem(id + ".SuggestionCount") || 20;
 	},
 	setup() {
 		async function addEmbeddings() {

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -536,7 +536,7 @@ export class TextAreaAutoComplete {
 	#update() {
 		let before = this.helper.getBeforeCursor();
 		if (before?.length) {
-			const m = before.match(/([^,;"]+)$/);
+			const m = before.match(/([^,;"|{}()]+)$/);
 			if (m) {
 				before = m[0]
 					.replace(/^\s+/, "")

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -494,7 +494,7 @@ export class TextAreaAutoComplete {
 	}
 
 	#getFilteredWords(term) {
-		term = term.toLocaleLowerCase();
+		term = term.toLocaleLowerCase()
 
 		const priorityMatches = [];
 		const prefixMatches = [];
@@ -536,9 +536,11 @@ export class TextAreaAutoComplete {
 	#update() {
 		let before = this.helper.getBeforeCursor();
 		if (before?.length) {
-			const m = before.match(/([^\s|,|;|"]+)$/);
+			const m = before.match(/([^,;"]+)$/);
 			if (m) {
-				before = m[0];
+				before = m[0]
+					.replace(/^\s+/, "")
+					.replace(/\s/g, "_") || null;
 			} else {
 				before = null;
 			}

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -501,11 +501,10 @@ export class TextAreaAutoComplete {
 		const includesMatches = [];
 		for (const word of Object.keys(this.words)) {
 			const lowerWord = word.toLocaleLowerCase();
-			// Show exact matches
-			// if (lowerWord === term) {
-			// 	// Dont include exact matches
-			// 	continue;
-			// }
+			if (lowerWord === term) {
+				// Dont include exact matches
+				continue;
+			}
 
 			const pos = lowerWord.indexOf(term);
 			if (pos === -1) {
@@ -624,7 +623,7 @@ export class TextAreaAutoComplete {
 					value = this.#escapeParentheses(value);
 
 					// Remove underscore
-					value = value.replace("_", " ");
+					value = value.replace(/_/g, " ");
 					
 					const afterCursor = this.helper.getAfterCursor();
 					const shouldAddSeparator = !afterCursor.trim().startsWith(this.separator.trim());

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -536,7 +536,7 @@ export class TextAreaAutoComplete {
 	#update() {
 		let before = this.helper.getBeforeCursor();
 		if (before?.length) {
-			const m = before.match(/([^,;"|{}()]+)$/);
+			const m = before.match(/([^,;"|{}()\n]+)$/);
 			if (m) {
 				before = m[0]
 					.replace(/^\s+/, "")

--- a/web/js/common/autocomplete.js
+++ b/web/js/common/autocomplete.js
@@ -494,17 +494,18 @@ export class TextAreaAutoComplete {
 	}
 
 	#getFilteredWords(term) {
-		term = term.toLocaleLowerCase()
+		term = term.toLocaleLowerCase();
 
 		const priorityMatches = [];
 		const prefixMatches = [];
 		const includesMatches = [];
 		for (const word of Object.keys(this.words)) {
 			const lowerWord = word.toLocaleLowerCase();
-			if (lowerWord === term) {
-				// Dont include exact matches
-				continue;
-			}
+			// Show exact matches
+			// if (lowerWord === term) {
+			// 	// Dont include exact matches
+			// 	continue;
+			// }
 
 			const pos = lowerWord.indexOf(term);
 			if (pos === -1) {
@@ -621,6 +622,10 @@ export class TextAreaAutoComplete {
 					  value = TextAreaAutoComplete.replacer(value);
 					}
 					value = this.#escapeParentheses(value);
+
+					// Remove underscore
+					value = value.replace("_", " ");
+					
 					const afterCursor = this.helper.getAfterCursor();
 					const shouldAddSeparator = !afterCursor.trim().startsWith(this.separator.trim());
 					this.helper.insertAtCursor(


### PR DESCRIPTION
1. Search values with underscore by using blank space instead underscore

![Screenshot 2024-12-17 044431](https://github.com/user-attachments/assets/ca923d87-193c-4aec-9a01-bd0675459a25)

2. Show values when type in dynamic prompt

![Screenshot 2024-12-17 044516](https://github.com/user-attachments/assets/ef9520e4-f096-42a2-a657-bfed7c6a6a0c)
![Screenshot 2024-12-17 044335](https://github.com/user-attachments/assets/bbffb28c-6256-4a34-880a-0f0db3584481)
![Screenshot 2024-12-17 044525](https://github.com/user-attachments/assets/464d6007-08eb-440c-9553-92526489bdd0)
