### PR TITLE
Image Feed Setting added to only display 'Save Image' node output(s) in Image Feed

### DIFF
--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -383,6 +383,14 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 			type: "number",
 		});
 
+		const saveNodeOnly = app.ui.settings.addSetting({
+		id: "pysssss.ImageFeed.SaveNodeOnly",
+		name: "🐍 Image Feed Display Nodes",
+		tooltip: `Only show images from Save Image nodes. This prevents temporary previews from appearing in the feed.`,
+		defaultValue: false,
+		type: "boolean",
+		});
+
 		const clearButton = $el("button.pysssss-image-feed-btn.clear-btn", {
 			textContent: "Clear",
 			onclick: () => {
@@ -533,6 +541,12 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 					const n = app.graph.getNodeById(detail.node.split(":")[0]);
 					if (n?.getInnerNodes) return;
 				}
+				
+				// Apply "Display Save Image Node Only" filter if setting is enabled
+					const nodeName = detail.node?.split(":")?.[0];
+					const node = app.graph.getNodeById(nodeName);
+				
+				if (saveNodeOnly.value && node?.type !== "SaveImage") return;
 
 				for (const src of detail.output.images) {
 					const href = `./view?filename=${encodeURIComponent(src.filename)}&type=${src.type}&

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -385,8 +385,8 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 
 		const saveNodeOnly = app.ui.settings.addSetting({
 		id: "pysssss.ImageFeed.SaveNodeOnly",
-		name: "🐍 Image Feed Display Nodes",
-		tooltip: `Only show images from Save Image nodes. This prevents temporary previews from appearing in the feed.`,
+		name: "🐍 Image Feed Display 'SaveImage' Nodes Only",
+		tooltip: `Only show images from SaveImage nodes. This prevents 'PreviewImage' node outputs from appearing in the feed.`,
 		defaultValue: false,
 		type: "boolean",
 		});

--- a/web/js/imageFeed.js
+++ b/web/js/imageFeed.js
@@ -385,8 +385,8 @@ Recommended: "enabled (max performance)" uness images are erroneously deduplicat
 
 		const saveNodeOnly = app.ui.settings.addSetting({
 		id: "pysssss.ImageFeed.SaveNodeOnly",
-		name: "🐍 Image Feed Display 'SaveImage' Nodes Only",
-		tooltip: `Only show images from SaveImage nodes. This prevents 'PreviewImage' node outputs from appearing in the feed.`,
+		name: "🐍 Image Feed Display 'SaveImage' Only",
+		tooltip: `Only show images from 'SaveImage' nodes. This prevents 'PreviewImage' node outputs from appearing in the feed.`,
 		defaultValue: false,
 		type: "boolean",
 		});


### PR DESCRIPTION
## Summary
This PR adds a new checkbox setting under Image Feed: "🐍 Image Feed Display 'SaveImage' Only" to allow users to only display images from the 'Save Image' node with a simple toggle. 

## Why?
When using additional pre- and post-processing elements in advanced workflows, it's helpful to visualize specific components through the workflow’s PreviewImage nodes. However, many of these elements are only intended for internal visibility and can clutter the Image Feed with unnecessary content. This option improves clarity and user experience by displaying only intentional outputs.

## How it works
- Adds a boolean setting saved in localStorage
- Filters images in the Image Feed based on node type (If toggled on 'SaveImage' Nodes only)
- Defaults to showing all images
