### PR TITLE
Fix a multi-process collision that causes import failure

### DIFF
--- a/pysssss.py
+++ b/pysssss.py
@@ -38,7 +38,7 @@ def get_ext_dir(subpath=None, mkdir=False):
     dir = os.path.abspath(dir)
 
     if mkdir and not os.path.exists(dir):
-        os.makedirs(dir)
+        os.makedirs(dir, exist_ok=True)
     return dir
 
 
@@ -50,7 +50,7 @@ def get_comfy_dir(subpath=None, mkdir=False):
     dir = os.path.abspath(dir)
 
     if mkdir and not os.path.exists(dir):
-        os.makedirs(dir)
+        os.makedirs(dir, exist_ok=True)
     return dir
 
 
@@ -59,7 +59,7 @@ def get_web_ext_dir():
     name = config["name"]
     dir = get_comfy_dir("web/extensions/pysssss")
     if not os.path.exists(dir):
-        os.makedirs(dir)
+        os.makedirs(dir, exist_ok=True)
     dir = os.path.join(dir, name)
     return dir
 


### PR DESCRIPTION
This is for fixing the case that somehow there's another pysssss instance that tries to create this extension
I am not fully certain how did I end up running into below errors, i.e., starting two pysssss instances?
But it helps my case, and I think the change improves robustness anyways.

```
Traceback (most recent call last):
  File "/app/ComfyUI/nodes.py", line 2133, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/ComfyUI/custom_nodes/ComfyUI-Custom-Scripts/__init__.py", line 10, in <module>
    if init():
  File "/app/ComfyUI/custom_nodes/ComfyUI-Custom-Scripts/pysssss.py", line 172, in init
    install_js()
  File "/app/ComfyUI/custom_nodes/ComfyUI-Custom-Scripts/pysssss.py", line 130, in install_js
    dst_dir = get_web_ext_dir()
  File "/app/ComfyUI/custom_nodes/ComfyUI-Custom-Scripts/pysssss.py", line 62, in get_web_ext_dir
    os.makedirs(dir)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/app/ComfyUI/web/extensions/pysssss'
```