### PR TITLE
Add feature: customizable prompt delimiters.

### DIFF
--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -326,7 +326,6 @@ app.registerExtension({
 					$el("td", [
 						$el("label", {
 							for: id.replaceAll(".", "-"),
-							textContent: name,
 						}),
 					]),
 					$el("td", [

--- a/web/js/autocompleter.js
+++ b/web/js/autocompleter.js
@@ -482,8 +482,32 @@ app.registerExtension({
 									},
 									onchange: (event) => {
 										const value = +event.target.value;
-										TextAreaAutoComplete.suggestionCount = value;;
+										TextAreaAutoComplete.suggestionCount = value;
 										localStorage.setItem(id + ".SuggestionCount", TextAreaAutoComplete.suggestionCount);
+									},
+								}),
+							]
+						),
+						$el(
+							"label",
+							{
+								textContent: "Prompt delimiters: ",
+								style: {
+									display: "block",
+								},
+							},
+							[
+								$el("input", {
+									type: "text",
+									value: TextAreaAutoComplete.promptDelimiters,
+									style: {
+										width: "80px",
+										fontFamily: "monospace"
+									},
+									onchange: (event) => {
+										const delimiters = event.target.value;
+										TextAreaAutoComplete.promptDelimiters = delimiters;
+										localStorage.setItem(id + ".PromptDelimiters", TextAreaAutoComplete.promptDelimiters);
 									},
 								}),
 							]
@@ -525,6 +549,7 @@ app.registerExtension({
 		TextAreaAutoComplete.insertOnEnter = localStorage.getItem(id + ".InsertOnEnter") !== "false";
 		TextAreaAutoComplete.lorasEnabled = localStorage.getItem(id + ".ShowLoras") === "true";
 		TextAreaAutoComplete.suggestionCount = +localStorage.getItem(id + ".SuggestionCount") || 20;
+		TextAreaAutoComplete.promptDelimiters = localStorage.getItem(id + ".PromptDelimiters") || ',;\"|{}()\n';
 	},
 	setup() {
 		async function addEmbeddings() {


### PR DESCRIPTION
1. This feature is useful when using other languages that has different delimiters (like Chinese) to write prompts.
<img width="1090" height="402" alt="image" src="https://github.com/user-attachments/assets/8bf6f057-9c17-42e3-b573-0d6ec87d85db" />
<img width="1227" height="493" alt="image" src="https://github.com/user-attachments/assets/193815f5-a78e-42d8-8df5-3a435234ac35" />

2. Fix a display bug.
<img width="1083" height="406" alt="image" src="https://github.com/user-attachments/assets/a7d4b850-9778-4e65-8802-7cb8d047f95c" />
<img width="1104" height="403" alt="image" src="https://github.com/user-attachments/assets/f23671f6-11cb-4822-9b7c-3c45533c9faa" />

